### PR TITLE
Generalize getSheetID to work for other spreadsheets

### DIFF
--- a/src/arbeitsstunden/sheet.js
+++ b/src/arbeitsstunden/sheet.js
@@ -86,12 +86,12 @@ async function copySheetToNewYear(nameBase, year) {
  */
 async function checkYearSheetsExists(year) {
   try {
-    await sheet.getSheetID(getSheetNameYear(sheetNames.stunden, year));
+    await sheet.getSheetID(process.env.SPREADSHEET_ID_MASTERDATA, getSheetNameYear(sheetNames.stunden, year));
   } catch (err) {
     await copySheetToNewYear(sheetNames.stunden, year);
   }
   try {
-    await sheet.getSheetID(getSheetNameYear(sheetNames.stundenSumme, year));
+    await sheet.getSheetID(process.env.SPREADSHEET_ID_MASTERDATA, getSheetNameYear(sheetNames.stundenSumme, year));
   } catch (err) {
     await copySheetToNewYear(sheetNames.stundenSumme, year);
   }

--- a/src/general/sheet.js
+++ b/src/general/sheet.js
@@ -118,7 +118,7 @@ export async function getSheets(spreadsheetID) {
  */
 export async function copySheet(spreadsheetID, sheetName) {
   const sheets = await auth();
-  const sheetID = await getSheetID(sheetName);
+  const sheetID = await getSheetID(spreadsheetID, sheetName);
   const request = {
     spreadsheetId: spreadsheetID,
     sheetId: sheetID,
@@ -134,11 +134,12 @@ export async function copySheet(spreadsheetID, sheetName) {
 
 /**
  * returns sheetID
+ * @param {string} spreadsheetID
  * @param {string} sheetName
  * @returns {Promise<number>}
  */
-export async function getSheetID(sheetName) {
-  const sheetArray = await getSheets(process.env.SPREADSHEET_ID_MASTERDATA);
+export async function getSheetID(spreadsheetID, sheetName) {
+  const sheetArray = await getSheets(spreadsheetID);
   const sheet = sheetArray.find((s) => s.properties.title === sheetName);
   return sheet.properties.sheetId;
 }
@@ -151,7 +152,7 @@ export async function getSheetID(sheetName) {
  */
 export async function renameSheet(spreadsheetID, oldName, newName) {
   const sheets = await auth();
-  const sheetID = await getSheetID(oldName);
+  const sheetID = await getSheetID(spreadsheetID, oldName);
 
   const requests = [];
   requests.push({


### PR DESCRIPTION
- Add "spreadsheetID" as an argument of getSheetID
- Add appropriate spreadsheet IDs to all calls of function getSheetID

Hintergrund:
Ich brauche für meinen Meldungen-Bot die funktion "Copy Sheet", welche intern "getSheetID" aufruft. Copy sheet hat eine "spreadsheetID" als parameter genommen, aber intern dann "getSheetID" immer hart mit "process.env.SPREADSHEET_ID_MASTERDATA" aufgerufen. 

Das war auf jeden fall falsch, da die funktion getSheetID in general/sheet.js liegt, nicht etwa in general/masterdata/sheet.js oder arbeitsstunden/sheet.js wo immer das Masterdata sheet genommen wird.

Die anderen Funktionen in  general/sheet.js nehmen alle eine spreadsheetID seit [!60](https://github.com/Roy0815/slack-service-bot/pull/60). Die funktion getSheetID ist mir damals wohl durch die Lappen gegangen (mea culpa).

In meinen Meldungen branch habe ich das bereits gemerged, da tut es.